### PR TITLE
VME-1176: Content-Security-Policy config section. Add X-Frame-Options and X-Content-Type-Options http headers to response.

### DIFF
--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -478,12 +478,12 @@ namespace VirtoCommerce.Storefront
                     var contentSecurityPolicyDirectives = Configuration.GetSection("ContentSecurityPolicy").GetChildren();
                     if (contentSecurityPolicyDirectives != null)
                     {
-                        var cspHeader = string.Empty;
+                        var cspHeaderBuilder = new StringBuilder();
                         foreach (var directive in contentSecurityPolicyDirectives)
                         {
-                            cspHeader += $"{directive.Key} {directive.Value};";
+                            cspHeaderBuilder.Append($"{directive.Key} {directive.Value};");
                         }
-                        context.Response.Headers["Content-Security-Policy"] = cspHeader;
+                        context.Response.Headers["Content-Security-Policy"] = cspHeaderBuilder.ToString();
                     }
                     context.Response.Headers["X-Frame-Options"] = "DENY";
                 }

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -465,6 +465,29 @@ namespace VirtoCommerce.Storefront
             app.Use(async (context, next) =>
             {
                 context.Response.Headers["X-Xss-Protection"] = "1";
+                if (context.Request.Path.Value.Contains("designer-preview"))
+                {
+                    var endPointUrl = Configuration.GetSection("VirtoCommerce:EndPoint:Url");
+                    if (endPointUrl != null)
+                    {
+                        context.Response.Headers["Content-Security-Policy"] = $"frame-src {endPointUrl.Value};";
+                    }
+                }
+                else
+                {
+                    var contentSecurityPolicyDirectives = Configuration.GetSection("ContentSecurityPolicy").GetChildren();
+                    if (contentSecurityPolicyDirectives != null)
+                    {
+                        var cspHeader = string.Empty;
+                        foreach (var directive in contentSecurityPolicyDirectives)
+                        {
+                            cspHeader += $"{directive.Key} {directive.Value};";
+                        }
+                        context.Response.Headers["Content-Security-Policy"] = cspHeader;
+                    }
+                    context.Response.Headers["X-Frame-Options"] = "DENY";
+                }
+                context.Response.Headers["X-Content-Type-Options"] = "nosniff";
                 await next();
             });
             app.UseMvc(routes =>


### PR DESCRIPTION
feature (configuration)
In config section "ContentSecurityPolicy" is possible to set whitelist of urls.
Using format:
"ContentSecurityPolicy": {
"directive-name": "value"
}
This header is applying for all stores pages. In page builder preview is using only frame-src.
Other headers are applying with determined value (with the same rule).

https://virtocommerce.atlassian.net/browse/VME-1176