### PR TITLE
VME-1176: Namespace for StringBuilder after refactor Startup.cs

### DIFF
--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
 using FluentValidation.AspNetCore;


### PR DESCRIPTION
Missed after https://github.com/VirtoCommerce/vc-com-storefront/pull/6/commits/fa5c4a29ac410edafcd4fc9dcc94b2b95fcafea7